### PR TITLE
Fix typo in channel_targets

### DIFF
--- a/.ci_support/linux_64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -5,7 +5,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/win_64_numpy1.20python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.20python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ boost:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - vs2019
 numpy:

--- a/.ci_support/win_64_numpy1.20python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.20python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ boost:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - vs2019
 numpy:

--- a/.ci_support/win_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ boost:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - vs2019
 numpy:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ boost:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge pytango_rc
 cxx_compiler:
 - vs2019
 numpy:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
-channels_target:
+channel_targets:
   - conda-forge pytango_rc


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

I made a typo in the `conda_build_config.yaml` file. I used `channels_target` instead of `channel_targets` :-( The 9.4.0rc1 version of pytango ended in the main channel...
